### PR TITLE
Improve social wording

### DIFF
--- a/_layout_foot.html.slim
+++ b/_layout_foot.html.slim
@@ -12,3 +12,4 @@ javascript:
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-49487014-1', '4am.tw');
   ga('send', 'pageview');
+

--- a/data.yml
+++ b/data.yml
@@ -11,6 +11,8 @@ og-type: "website"
 og-image: "http://4am.tw/images/fb800.png"
 fb-admins: "612130717"
 
+social-wording: "It's 4am in Taiwan and people are still occupying the parliament to protect democracy."
+
 photos:
   '001':
   '002':

--- a/partials/_header.html.slim
+++ b/partials/_header.html.slim
@@ -13,6 +13,6 @@ ul.menu-list
   ul.social
     h2 Sharing the Truth. #CongressOccupied
     li
-      a.twitter-share-button onclick="window.open(this.href, 'twitter-share-dialog', 'width=480,height=320'); return false;" href="https://twitter.com/share?url=#{CGI.escape('http://4am.tw')}&text=#{CGI.escape("It's 4am in Taiwan and people are still occupying the parliament to protect democracy.")}&related=4amtw&hashtags=CongressOccupied&lang=en" = "Tweet"
+      a.twitter-share-button onclick="window.open(this.href, 'twitter-share-dialog', 'width=480,height=320'); return false;" href="https://twitter.com/share?url=#{CGI.escape('http://4am.tw')}&text=#{CGI.escape(sns_wording)}&related=4amtw&hashtags=CongressOccupied&lang=en" = "Tweet"
     li
       <a href="#" onclick="window.open('https://www.facebook.com/sharer/sharer.php?u='+encodeURIComponent('http://4am.tw'), 'facebook-share-dialog', 'width=626,height=436'); return false;">facebook</a>

--- a/partials/_header.html.slim
+++ b/partials/_header.html.slim
@@ -11,8 +11,8 @@ ul.menu-list
   = nav_link_to("We need YOUR support" , "/we-need-your-support/")
   = nav_link_to("Who we are" , "/who-we-are/")
   ul.social
-    h2 Sharing the Truth.
+    h2 Sharing the Truth. #CongressOccupied
     li
-      <a href="https://twitter.com/share" class="twitter-share-button" data-lang="en">Tweet</a>
+      a.twitter-share-button onclick="window.open(this.href, 'twitter-share-dialog', 'width=480,height=320'); return false;" href="https://twitter.com/share?url=#{CGI.escape('http://4am.tw')}&text=#{CGI.escape("It's 4am in Taiwan and people are still occupying the parliament to protect democracy.")}&related=4amtw&hashtags=CongressOccupied&lang=en" = "Tweet"
     li
       <a href="#" onclick="window.open('https://www.facebook.com/sharer/sharer.php?u='+encodeURIComponent('http://4am.tw'), 'facebook-share-dialog', 'width=626,height=436'); return false;">facebook</a>

--- a/partials/_header.html.slim
+++ b/partials/_header.html.slim
@@ -13,6 +13,6 @@ ul.menu-list
   ul.social
     h2 Sharing the Truth. #CongressOccupied
     li
-      a.twitter-share-button onclick="window.open(this.href, 'twitter-share-dialog', 'width=480,height=320'); return false;" href="https://twitter.com/share?url=#{CGI.escape('http://4am.tw')}&text=#{CGI.escape(sns_wording)}&related=4amtw&hashtags=CongressOccupied&lang=en" = "Tweet"
+      a.twitter-share-button onclick="window.open(this.href, 'twitter-share-dialog', 'width=480,height=320'); return false;" href="https://twitter.com/share?url=#{CGI.escape('http://4am.tw')}&text=#{CGI.escape(data["social-wording"])}&related=4amtw&hashtags=CongressOccupied&lang=en" = "Tweet"
     li
       <a href="#" onclick="window.open('https://www.facebook.com/sharer/sharer.php?u='+encodeURIComponent('http://4am.tw'), 'facebook-share-dialog', 'width=626,height=436'); return false;">facebook</a>

--- a/view_helpers.rb
+++ b/view_helpers.rb
@@ -14,10 +14,4 @@ module ViewHelpers
     end
     content_tag(:li, link_to(name, href, :class => active) )
   end
-
-  # FIXME: should be in a config
-  def sns_wording
-    "It's 4am in Taiwan and people are still occupying the parliament to protect democracy."
-  end
-
 end

--- a/view_helpers.rb
+++ b/view_helpers.rb
@@ -15,4 +15,9 @@ module ViewHelpers
     content_tag(:li, link_to(name, href, :class => active) )
   end
 
+  # FIXME: should be in a config
+  def sns_wording
+    "It's 4am in Taiwan and people are still occupying the parliament to protect democracy."
+  end
+
 end

--- a/we-need-your-support/index.html.slim
+++ b/we-need-your-support/index.html.slim
@@ -3,7 +3,7 @@ h2.sub-header We Need YOUR Support
 markdown:
   ## Social Sharing
 
-  1. Share this website via <a href="https://twitter.com/4amtw" target="_blank">Twitter @4am.tw</a>.
+  1. Share this website via <a href="https://twitter.com/4amtw" target="_blank">Twitter @4amtw</a>.
   or <a href="https://www.facebook.com/sunflowermovement" target="_blank">Facebook</a> with hashtag *#CongressOccupied*
   2. Upload a sunflower photo to show your support
   3. Stay tuned with us for the latest update


### PR DESCRIPTION
![screen shot 2014-03-29 at 13 25 31](https://cloud.githubusercontent.com/assets/10737/2557431/a742ab58-b702-11e3-9f95-290cb84ce7b0.png)
1. Added texts to twitter sharing. Feel free to improve the wording.
2. Added hashtag "#CongressOccupied" to the text of twitter sharing.
3. Added hashtag "#CongressOccupied" to the sidebar of sharing block.
4. After shared on Twitter it will show related twitter account "4amtw".
5. Fix wrong twitter account name on "We need your support" page.

Note: both Twitter and Facebook sharing are still working _without_ javascript ;)
