### PR TITLE
add word-break to .timeline to fix overflow due to a URL line

### DIFF
--- a/sass/partials/_timeline.scss
+++ b/sass/partials/_timeline.scss
@@ -2,6 +2,7 @@
   position: relative;
   width: 97%;
   float: right;
+  word-break: break-all;
   @include at-breakpoint($pad) {
     float: none;
     width: 95%;


### PR DESCRIPTION
A URL in section 2014/4/9 12:00 cause timeline overflow and breaking RWD layout. 
![2015-03-18 12 51 52](https://cloud.githubusercontent.com/assets/165936/6702909/e7251404-cd6d-11e4-9366-12292c6af2b2.png)
